### PR TITLE
Fix resetNotifications parameter and clean return types

### DIFF
--- a/lib/src/nit_notification_listener_widget.dart
+++ b/lib/src/nit_notification_listener_widget.dart
@@ -25,7 +25,7 @@ class NitNotificationListenerWidget<NotificationClass> extends ConsumerWidget {
             notificationPresenter(context, state.message! as NotificationClass);
             ref
                 .read(nitNotificationsStateProvider(NotificationClass).notifier)
-                .resetNotifications(context);
+                .resetNotifications();
           }
         },
       );

--- a/lib/src/nit_notifications/nit_notification.dart
+++ b/lib/src/nit_notifications/nit_notification.dart
@@ -15,10 +15,10 @@ class NitNotification {
   NitNotification.warning(this.text) : type = NitNotificationTypesEnum.warning;
   NitNotification.success(this.text) : type = NitNotificationTypesEnum.success;
 
-  static Future showNotificationFlash(
+  static Future<bool?> showNotificationFlash(
     BuildContext context,
     NitNotification notification,
-  ) async {
+  ) {
     return context.showFlash<bool>(
       duration: const Duration(seconds: 3),
       builder: (context, controller) {

--- a/lib/src/ref_extension.dart
+++ b/lib/src/ref_extension.dart
@@ -2,14 +2,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'state/nit_notifications_state.dart';
 
 extension NitNotificationsRefExtension on Ref {
-  notifyUser<NotificationClass>(NotificationClass notification) {
+  void notifyUser<NotificationClass>(NotificationClass notification) {
     read(nitNotificationsStateProvider(NotificationClass).notifier)
         .notifyUser(notification);
   }
 }
 
 extension NitNotificationsWidgetRefExtension on WidgetRef {
-  notifyUser<NotificationClass>(NotificationClass notification) {
+  void notifyUser<NotificationClass>(NotificationClass notification) {
     read(nitNotificationsStateProvider(NotificationClass).notifier)
         .notifyUser(notification);
   }

--- a/lib/src/state/nit_notifications_state.dart
+++ b/lib/src/state/nit_notifications_state.dart
@@ -14,11 +14,11 @@ class NitNotificationsState extends _$NitNotificationsState {
     );
   }
 
-  notifyUser<MessageClass>(MessageClass message) {
+  void notifyUser<MessageClass>(MessageClass message) {
     state = state.copyWith(message: message);
   }
 
-  resetNotifications(BuildContext context) {
+  void resetNotifications() {
     state = state.copyWith(message: null);
   }
 }


### PR DESCRIPTION
## Summary
- remove unused context parameter in resetNotifications
- clarify void return types for notifyUser extensions and state
- specify return type of showNotificationFlash

## Testing
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8d7d21c8832ca59e2184dcff708a