### PR TITLE
Add basic tests for provider and widget behavior

### DIFF
--- a/test/nit_notification_listener_widget_test.dart
+++ b/test/nit_notification_listener_widget_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nit_riverpod_notifications/nit_riverpod_notifications.dart';
+
+void main() {
+  testWidgets('listener widget invokes presenter and resets state', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    String? received;
+
+    await tester.pumpWidget(ProviderScope(
+      parent: container,
+      child: NitNotificationListenerWidget<String>(
+        notificationPresenter: (context, notification) {
+          received = notification;
+        },
+        child: const SizedBox.shrink(),
+      ),
+    ));
+
+    container.read(nitNotificationsStateProvider(String).notifier).notifyUser('hello');
+
+    await tester.pump();
+    await tester.pump();
+
+    expect(received, 'hello');
+    expect(container.read(nitNotificationsStateProvider(String)).message, isNull);
+  });
+}

--- a/test/nit_notifications_state_test.dart
+++ b/test/nit_notifications_state_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nit_riverpod_notifications/nit_riverpod_notifications.dart';
+
+void main() {
+  testWidgets('notifier stores and resets messages', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(ProviderScope(parent: container, child: const SizedBox.shrink()));
+
+    final notifier = container.read(nitNotificationsStateProvider(String).notifier);
+
+    notifier.notifyUser('hello');
+    await tester.pump();
+
+    expect(container.read(nitNotificationsStateProvider(String)).message, 'hello');
+
+    final context = tester.element(find.byType(SizedBox));
+    notifier.resetNotifications(context);
+    await tester.pump();
+
+    expect(container.read(nitNotificationsStateProvider(String)).message, isNull);
+  });
+}

--- a/test/nit_riverpod_notifications_test.dart
+++ b/test/nit_riverpod_notifications_test.dart
@@ -1,8 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nit_riverpod_notifications/nit_riverpod_notifications.dart';
+
 void main() {
-  // test('adds one to input values', () {
-  // final calculator = Calculator();
-  // expect(calculator.addOne(2), 3);
-  // expect(calculator.addOne(-7), -6);
-  // expect(calculator.addOne(0), 1);
-  // });
+  test('notification constructors set correct type', () {
+    expect(NitNotification.success('ok').type, NitNotificationTypesEnum.success);
+    expect(NitNotification.warning('w').type, NitNotificationTypesEnum.warning);
+    expect(NitNotification.error('e').type, NitNotificationTypesEnum.error);
+  });
 }

--- a/test/ref_extension_test.dart
+++ b/test/ref_extension_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nit_riverpod_notifications/nit_riverpod_notifications.dart';
+
+class _NotifyWidget extends ConsumerWidget {
+  const _NotifyWidget({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.notifyUser<String>(message);
+    return const SizedBox.shrink();
+  }
+}
+
+void main() {
+  testWidgets('ref extension notifies user', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(ProviderScope(
+      parent: container,
+      child: const _NotifyWidget(message: 'ping'),
+    ));
+
+    await tester.pump();
+
+    expect(container.read(nitNotificationsStateProvider(String)).message, 'ping');
+  });
+}


### PR DESCRIPTION
## Summary
- add tests for notifier state management
- add tests for ref extension usage
- add tests for notification listener widget
- add simple notification constructor test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8f4ead2c832c87dbcf4bfbac7d47