### PR TITLE
Remove unused material import

### DIFF
--- a/lib/src/state/nit_notifications_state.dart
+++ b/lib/src/state/nit_notifications_state.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 


### PR DESCRIPTION
## Summary
- clean up `NitNotificationsState` by removing a flutter import

## Testing
- `dart analyze` *(fails: dart not installed)*
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684d9276a3ac832ca54dda3c483c2cde