### PR TITLE
Fix notifications state test

### DIFF
--- a/test/nit_notifications_state_test.dart
+++ b/test/nit_notifications_state_test.dart
@@ -17,8 +17,7 @@ void main() {
 
     expect(container.read(nitNotificationsStateProvider(String)).message, 'hello');
 
-    final context = tester.element(find.byType(SizedBox));
-    notifier.resetNotifications(context);
+    notifier.resetNotifications();
     await tester.pump();
 
     expect(container.read(nitNotificationsStateProvider(String)).message, isNull);


### PR DESCRIPTION
## Summary
- update the notifications state test to match API

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d9266f3ec832c941c77588133e79f